### PR TITLE
Bug fix for capturing a canvas

### DIFF
--- a/browser_extension/src/store/ActionMap.js
+++ b/browser_extension/src/store/ActionMap.js
@@ -230,11 +230,15 @@ export default class ActionMap {
             action.boundingBox = newBoundingBox
             action.clickPosition = newClickPosition
           } else {
-            const newAction = new Action(parent, action.target, {
-              type: action.type,
-            })
+            const newAction = new Action(
+              parent,
+              action.target,
+              newBoundingBox,
+              {
+                type: action.type,
+              }
+            )
 
-            newAction.boundingBox = newBoundingBox
             newAction.clickPosition = newClickPosition
             newAction.parent = undefined
             newAction.position = position++

--- a/server/client/src/pages/PlayerPage.vue
+++ b/server/client/src/pages/PlayerPage.vue
@@ -31,10 +31,10 @@ function seekToFrame(frame) {
 function checkBoundingBox(event, action) {
   return (
     action.boundingBox.length === 4 &&
-    event.clientX >= action.boundingBox[0] &&
-    event.clientY >= action.boundingBox[1] &&
-    event.clientX <= action.boundingBox[2] &&
-    event.clientY <= action.boundingBox[3]
+    event.pageX >= action.boundingBox[0] &&
+    event.pageY >= action.boundingBox[1] &&
+    event.pageX <= action.boundingBox[2] &&
+    event.pageY <= action.boundingBox[3]
   )
 }
 


### PR DESCRIPTION
fixed canvas action duplication to include type. Fixed playback bounding box check to use page coordinates instead of view coordinates